### PR TITLE
Get default GKE version from CLI if GKE_VERSION not set

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,8 +30,6 @@ DNS_SA_EMAIL="${DNS_SA}"@"${PROJECT_NAME}".iam.gserviceaccount.com
 SERVICES_POOL="workload-services"
 WORKSPACES_POOL="workload-workspaces"
 
-GKE_VERSION=${GKE_VERSION:="1.20.8-gke.900"}
-
 GITPOD_VERSION=${GITPOD_VERSION:="aledbf-mk3.68"}
 
 function check_prerequisites() {
@@ -318,6 +316,15 @@ function install() {
         echo "Cluster with name ${CLUSTER_NAME} already exists. Skip cluster creation.";
         gcloud container clusters get-credentials --region="${REGION}" "${CLUSTER_NAME}"
     else
+        if [ -z "${GKE_VERSION}" ]; then
+            echo "Getting default version from regular channel"
+            GKE_VERSION=$(gcloud container get-server-config \
+                --flatten="channels" \
+                --filter="channels.channel=REGULAR" \
+                --format="value(channels.defaultVersion)" \
+                --region="${REGION}")
+        fi
+
         # shellcheck disable=SC2086
         gcloud container clusters \
             create "${CLUSTER_NAME}" \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The default version of GKE was `1.20.8-gke.900` which is no longer available. If the `GKE_VERSION` variable is not set, it queries the `defaultVersion` from the REGULAR channel

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
`make install`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Set the GKE version to the latest default version if no version provided
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
