### PR TITLE
Make sure that PREEMPTIBLE is unset appropriately

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,8 @@ function check_prerequisites() {
     if [ -n "${PREEMPTIBLE}" ] && [ "${PREEMPTIBLE}" == "true" ]; then
         PREEMPTIBLE="--preemptible"
         export PREEMPTIBLE
+    else
+        unset PREEMPTIBLE
     fi
 
     NODES_LOCATIONS=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The current configuration in the .env.example file has PREEMPTIBLE=false, this is not handled and leads to a failure during the cluster creation:
ERROR: (gcloud.container.clusters.create) unrecognized arguments: false

This value needs to be either set to --preemptible (which was already handled) or removed, which is this modification.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
No fix# that I'm aware of, this was broken for me so I fixed it and wanted to send the change back.

## How to test
<!-- Provide steps to test this PR -->
run an install on GKE with the .env value set like this : 
PREEMPTIBLE=false

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No change required.
