### PR TITLE
added gitpod config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DOMAIN=mygitpod.example.com
 # Set the name of the GCP Project. If the project does not exists, it will create a new one.
 # https://cloud.google.com/resource-manager/docs/creating-managing-projects
 PROJECT_NAME=gitpod
+
 # Set details about the billing account
 # https://cloud.google.com/billing/docs/concepts
 BILLING_ACCOUNT=XXXXX-XXXXX-XXXXX
@@ -11,6 +12,7 @@ BILLING_ACCOUNT=XXXXX-XXXXX-XXXXX
 # Set the region of the cluster's control plane and nodes
 # https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters
 REGION=us-central1
+
 # Set the zones in the region.
 # By default (empty value) it will distribute the nodes in the region (at least three zones)
 # https://cloud.google.com/compute/docs/regions-zones#available
@@ -18,13 +20,15 @@ ZONES=
 
 # The name of the GKE cluster
 CLUSTER_NAME=gitpod
+
 # Set if we wan to use Preemptible nodes
 # Preemptible VMs are Compute Engine VM instances that last a maximum of 24 hours in general.
 # https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms
-PREEMPTIBLE=false
+PREEMPTIBLE=--preemptible
 
 # The email address for cert-manager wildcard SSL certificate
 LETSENCRYPT_EMAIL=my@email
+
 # Set if we want to use Cloud DNS to manage the DNS service.
 # https://cloud.google.com/dns
 SETUP_MANAGED_DNS=true

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# glcoud
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && sudo apt-get update \
+    && sudo apt-get -y install google-cloud-sdk

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image: 
+  file: .gitpod.Dockerfile
+tasks:
+- init: |
+    cp .env.example .env
+  command: |
+    mkdir -p ~/.kube
+    mkdir -p ~/.config/gcloud
+    open .env
+    gcloud auth login
+    make install

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: ## Build docker image containing the required tools for the installation
 DOCKER_RUN_CMD = docker run -it \
 	--pull always \
 	--volume $$HOME/.config/gcloud:/root/.config/gcloud \
-	--volume $$HOME/.kube/config:/root/.kube/config \
+	--volume $$HOME/.kube:/root/.kube \
 	--volume $$PWD:/gitpod \
 	${IMG} $(1)
 


### PR DESCRIPTION
This PR adds a config so that users can run the installer from within gitpod.
It also fixes #6 and runs some commands (e.g. creating and opening `.env`) to streamline the process.