### PR TITLE
use `--preemptable` appropriately when set to false

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,10 +61,11 @@ function check_prerequisites() {
         export REGION
     fi
 
+    PREEMPTIBLE_NODES=
     if [ -n "${PREEMPTIBLE}" ] && [ "${PREEMPTIBLE}" == "true" ]; then
-        PREEMPTIBLE="--preemptible"
-        export PREEMPTIBLE
+        PREEMPTIBLE_NODES="--preemptible"
     fi
+    export PREEMPTIBLE_NODES
 
     NODES_LOCATIONS=
     if [ -n "${ZONES}" ]; then
@@ -90,7 +91,7 @@ function create_node_pool() {
         --node-labels="${NODES_LABEL}" \
         --max-pods-per-node=110 --min-nodes=1 --max-nodes=50 \
         --region="${REGION}" \
-        "${PREEMPTIBLE}"
+        ${PREEMPTIBLE_NODES}
 }
 
 function create_secrets() {
@@ -362,7 +363,7 @@ function install() {
             --max-pods-per-node=110 --default-max-pods-per-node=110 \
             --min-nodes=0 --max-nodes=1 \
             --addons=HorizontalPodAutoscaling,NodeLocalDNS,NetworkPolicy \
-            ${NODES_LOCATIONS} ${PREEMPTIBLE}
+            ${NODES_LOCATIONS} ${PREEMPTIBLE_NODES}
 
         # delete default node pool (is not possible to create a cluster without nodes)
         gcloud --quiet container node-pools delete default-pool --cluster="${CLUSTER_NAME}" --region="${REGION}"


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

Currently, As we seem to use the `{PREEMPTABLE}` env directly,
It causes the following error when set to `false`:

```
ERROR: (gcloud.container.clusters.create) unrecognized arguments: false
```

This PR updates to use a separate variable, which is set `--preemptable`
when `PREEMPTABLE` is set to true, **empty otherwise**. Thus, preventing
`false` to mistakenly passed as an argument.

This PR also updates the usage at `gcloud.container.node-pools.create`
to not pass empty argument when the value is `false`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod-gke-guide/pull/7


## How to test
<!-- Provide steps to test this PR -->
`make install` with `PREEMPTIABLE` set to `false`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix a cmd arg issue when `PREEMPTIBLE` is set to `false`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
