### PR TITLE
Spelling, updated to match intended use (create environment not install Gitpod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Running Gitpod in [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
 
-> **IMPORTANT** This guide exists as a simple and reliable way of creating a Gitpod instance in GKE. It
+> **IMPORTANT** This guide exists as a simple and reliable way of creating an environment in GKE that can run Gitpod. It
 > is not designed to cater for every situation. If you find that it does not meet your exact needs,
 > please fork this guide and amend it to your own needs.
 
@@ -21,7 +21,7 @@ Before starting the installation process, you need:
 make install
 ```
 
-The whole process takes around twenty minutes. In the end, the following resources are created:
+The whole process takes around twenty minutes. In the end, the following resources are created. These are the GCP versions of the [components Gitpod requires](https://www.gitpod.io/docs/self-hosted/latest/required-components):
 
 - a GKE cluster running Kubernetes v1.21 ([rapid channel](https://cloud.google.com/kubernetes-engine/docs/release-notes-rapid)).
 - GCP L4 load balancer.
@@ -30,9 +30,8 @@ The whole process takes around twenty minutes. In the end, the following resourc
 - In-cluster docker registry using [Cloud Storage](https://cloud.google.com/storage) as storage backend.
 - [calico](https://docs.projectcalico.org) as CNI and NetworkPolicy implementation.
 - [cert-manager](https://cert-manager.io/) for self-signed SSL certificates.
-- [gitpod.io](https://github.com/gitpod-io/gitpod) deployment.
 
-Upon completion, it will print the config for resource (including passwords) and instructions on what
+Upon completion, it will print the config for the resources created (including passwords) and instructions on what
 to do next. **IMPORTANT** - running the `make install` command after the initial install will change
 your database password which will require you to update your KOTS configuration.
 
@@ -55,7 +54,7 @@ your database password which will require you to update your KOTS configuration.
   proxy-5998488f4c-t8vkh   0/1     Init 0/1  0          5m
   ```
   
-  The most likely reason is because the [DNS01 challenge](https://cert-manager.io/docs/configuration/acme/dns01/) has yet to resolve. If using `SETUP_MANAGED_DNS`, you will need to update your DNS records to point to the GCP Cloud DNS nameserver.
+  The most likely reason is that the [DNS01 challenge](https://cert-manager.io/docs/configuration/acme/dns01/) has yet to resolve. If using `SETUP_MANAGED_DNS`, you will need to update your DNS records to point to the GCP Cloud DNS nameserver.
 
   Once the DNS record has been updated, you will need to delete all cert-manager pods to retrigger the certificate request
 
@@ -70,69 +69,6 @@ your database password which will require you to update your KOTS configuration.
   NAME                        READY   SECRET                      AGE
   https-certificates          True    https-certificates          5m
   ```
-
-## Verify the installation
-
-First, check that Gitpod components are running.
-
-```shell
-kubectl get pods
-NAME                                             READY   STATUS      RESTARTS   AGE
-agent-smith-bz97r                                2/2     Running     0          95m
-agent-smith-dll6b                                2/2     Running     0          95m
-agent-smith-kvrs5                                2/2     Running     0          95m
-blobserve-74599b4b98-5t9dq                       2/2     Running     0          95m
-cloudsqlproxy-cloud-sql-proxy-7556c57c4d-zqptx   1/1     Running     0          95m
-cloudsqlproxy-session-ldl9h                      0/1     Completed   0          95m
-content-service-758878c6c-b4sqh                  1/1     Running     0          95m
-dashboard-758f94ccf5-qk8cm                       1/1     Running     0          95m
-image-builder-mk3-55f948b89f-m6qbk               2/2     Running     0          95m
-jaeger-operator-6cc9f79cc8-dfkjh                 1/1     Running     0          95m
-messagebus-0                                     1/1     Running     0          95m
-migrations-5jmkx                                 0/1     Completed   0          95m
-openvsx-proxy-0                                  1/1     Running     0          95m
-proxy-55665d8765-n2b2w                           2/2     Running     0          95m
-registry-facade-4c7tz                            2/2     Running     0          95m
-registry-facade-5dxfx                            2/2     Running     0          95m
-registry-facade-gxmhv                            2/2     Running     0          95m
-server-ccb459f85-8vgfn                           2/2     Running     0          95m
-ws-daemon-6qrjf                                  2/2     Running     0          95m
-ws-daemon-hslz7                                  2/2     Running     0          95m
-ws-daemon-hzw8h                                  2/2     Running     0          95m
-ws-manager-8f6bc54f4-r67kk                       1/1     Running     0          95m
-ws-manager-bridge-56d7978664-6l6ht               2/2     Running     0          95m
-ws-proxy-fbc47486d-kqdvj                         1/1     Running     0          95m
-ws-scheduler-5c5d9f998-6zxmz                     2/2     Running     0          95m
-
-```
-
-### Test Gitpod workspaces
-
-When the provisioning and configuration of the cluster is done, the script shows the URL of the load balancer,
-like:
-
-```shell
-Load balancer IP address: XXX.XXX.XXX.XXX
-```
-
-Please open the URL `https://<domain>/workspaces`.
-It should display the Gitpod login page similar to the next image.
-
-*DNS propagation* can take several minutes.
-
-![Gitpod login page](./images/gitpod-login.png "Gitpod Login Page")
-
-----
-
-## Delete Gitpod from your cluster
-
-Remove Gitpod from your cluster running:
-
-```shell
-kubectl get configmaps gitpod-app \
-  -o jsonpath='{.data.app\.yaml}' | \
-  kubectl delete -f -
-```
 
 ## Destroy the cluster and GCP resources
 


### PR DESCRIPTION
## Description
- Minor spelling & grammar mistakes
- Updated wording to match intended use: create an environment on GKE to then install Gitpod. Rather than doing the latter AND installing gitpod. 
- Removed bits around installing Gitpod. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
