### PR TITLE
chore: fix typo in .env.example preemptible instances description

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ ZONES=
 
 # The name of the GKE cluster
 CLUSTER_NAME=gitpod
-# Set if we wan to use Preemptible nodes
+# Set if we want to use Preemptible nodes
 # Preemptible VMs are Compute Engine VM instances that last a maximum of 24 hours in general.
 # https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms
 PREEMPTIBLE=false


### PR DESCRIPTION
## Description

This pull request fixes a small typo in the .env.example preeemptible instance description.

This is a non-functional change and will not impact testing or will require release notes.
