### PR TITLE
Add Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# Running Gitpod in [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
+
+ ## 📣 [IMPORTANT] This repo is being deprecated in favor of the [single cluster reference architecture](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) and the corresponding [Terraform config](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/aws).
+
+**What?** 
+
+We are deprecating this guide in favor of our [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch) (specifically the [single cluster variant](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch)) that include both a guided walk-through and a `Terraform` configuration.
+
+**Why?**
+
+From your feedback, we’ve learned that the guide has several shortcomings:
+
+- It is not obvious what the guide does: it is more a black box than a sensible starting point for creating the infrastructure that works for you.
+- One size fits all: it was not flexible enough if you wish to customize the infrastructure being created.
+- No incremental upgrades: If a version of a component changes, you’d have to recreate the infrastructure.
+
+Due to the feedback above we’ve decided to move to a more open and industry-standard way of speaking about the recommended infrastructure in the form of our new [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). These are descriptions of what the ideal infrastructure for Gitpod looks like depending on your circumstances. They include both a text version as well as a Terraform configuration that helps you create this infrastructure automatically - similarly to this guide. We believe these provide the following benefits: 
+
+- They are based on a popular `Infrastructure as Code (IaC)` solution (`Terraform`), which should facilitate maintenance for you (and us) via features such as incremental upgrades.
+- They are easier to parse, as they are configuration files rather than a script. This should make customizations easier.
+- They provide a detailed walkthrough for those that do not want to use Terraform.
+- We already leverage these in our nightly testing to provide further validation and reliability of them when used to run Gitpod.
+
+**Impact?**
+
+Going forward, Gitpod will only officially support the [reference architectures](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch). If you can, we would advise you to switch towards using these - this would require you to recreate your infrastructure using the new Terraform configurations or guide. Staying on infrastructure created by this guide *should* work going forward, however, we cannot guarantee this in perpetuity.
+
+—> The Reference Architectures are still in `beta` or `alpha` while we gather more feedback. Please do reach out to us on Discord or via [support](https://www.gitpod.io/support) with any problems or feedback.
+
+------
+
+## Running Gitpod in [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
 
 > **IMPORTANT** This guide exists as a simple and reliable way of creating an environment in GKE that can run Gitpod. It
 > is not designed to cater for every situation. If you find that it does not meet your exact needs,


### PR DESCRIPTION
## Description
Adds a deprecation notice and instead points to the Single Cluster Reference Architecture
- We'll also need to close the issues section
## How to test
Read through changed files

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

